### PR TITLE
closes #1 - added rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### v0.3
+- use the [ratelimit](https://pypi.org/project/ratelimit/) library to limit API requests to 45 per minute, as per [the official docs](https://wallhaven.cc/help/api#limits)
+
 #### v0.2
 - added `Wallhaven.get_search_pages()` and `Wallhaven.get_collection_pages()`
     - these methods return generators that iterate through all pages in a response, rather than requiring a specific page as a parameter

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project uses these libraries:
 - [requests](https://pypi.org/project/requests/)
 - [urllib3](https://pypi.org/project/urllib3/)
 - [dataclasses](https://pypi.org/project/dataclasses/) (for Python 3.6)
+- [ratelimit](https://pypi.org/project/ratelimit/)
 - [responses](https://pypi.org/project/responses/) (for testing only)
 
 #### Links

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pywallhaven
-version = 0.2
+version = 0.3
 author = Jason Tait
 description = A wrapper for the wallhaven.cc API
 long_description = file: README.md
@@ -22,3 +22,4 @@ install_requires =
     requests >= "2.25.1"
     urllib3 >= "1.26.3"
     dataclasses >= "0.8"; python_version == "3.6"
+    ratelimit >= "2.2.1"


### PR DESCRIPTION
added rate limiting of 45 calls per minute to __get_endpoint() which is responsible for all API calls